### PR TITLE
Add missing __init__.py

### DIFF
--- a/qc_grader/utilities/__init__.py
+++ b/qc_grader/utilities/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# (C) Copyright IBM 2022
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.


### PR DESCRIPTION
## Changes

- Add `__init__.py` under `utilities`

## Implementation details

- Execute `cp ../grader/__init__.py` . under `qc_grader/utilities`

## How to read this PR

Features to be reviewed: With `pip install git+https://github.com/qiskit-community/Quantum-Challenge-Grader.git`, we cannot import `qc_grader.graph_util` in [summer-school/2021/resources/lab-notebooks/lab-2.ipynb](https://github.com/Qiskit/platypus/blob/main/notebooks/summer-school/2021/resources/lab-notebooks/lab-2.ipynb). After the fix, for example, `pip install git+https://github.com/derwind/Quantum-Challenge-Grader.git@add-init-py` will allow import.