### PR TITLE
update qiskit

### DIFF
--- a/requirements-qiskit.txt
+++ b/requirements-qiskit.txt
@@ -1,3 +1,3 @@
-qiskit[visualization]~=1.0.0
+qiskit[visualization]~=1.1.0
 qiskit-ibm-runtime~=0.21.0
 qiskit-aer~=0.13.3


### PR DESCRIPTION
this PR updates the Qiskit version (`1.1.x`) installed by the grader client

