### PR TITLE
update python>=3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=REQUIREMENTS,
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     extras_require={
         'qiskit': QISKIT_REQUIREMENTS,
         'jupyter': JUPYTER_REQUIREMENTS


### PR DESCRIPTION
Update python version requirement to >=3.10 because the [json encoder](https://github.com/qiskit-community/Quantum-Challenge-Grader/blob/9ec0aa6ac3a7ff8650e274e3574ba18e62d1fd41/qc_grader/custom_encoder/json_encoder.py#L55) uses pattern matching which is only available after 3.10.