### PR TITLE
Fix #179 estimator construction parameter in lab2 ex6 for fall fest 2024

### DIFF
--- a/qc_grader/challenges/fall_fest24/lab2.py
+++ b/qc_grader/challenges/fall_fest24/lab2.py
@@ -73,7 +73,7 @@ def grade_lab2_ex6(cost_func: Callable) -> None:
     isa_circuits = pm.run(ansatz)
     choc_op = SparsePauliOp(['ZII', 'IZI', 'IIZ'])
     hamiltonian_isa = choc_op.apply_layout(layout=isa_circuits.layout)
-    estimator = Estimator(backend=aer_sim)
+    estimator = Estimator(mode=aer_sim)
     
     callback_dict = {
         "prev_vector": None,


### PR DESCRIPTION
As stated in the [EstimatorV2 doc](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.EstimatorV2), the constructor only accepts `mode` and `options` as parameters. Furthermore, the `mode` param accepts a `Backend` as input, so i've replaced the wrong `backend` param with it.

I hope this helps, let me know if i can do something else :) 

Closes #179 